### PR TITLE
Remove over-matching "**/build/**" pattern from alwaysIgnore.ts

### DIFF
--- a/src/utils/alwaysIgnore.ts
+++ b/src/utils/alwaysIgnore.ts
@@ -40,7 +40,6 @@ export const ALWAYS_IGNORE = [
   "dist/",
   "**/dist/**",
   "build/",
-  "**/build/**",
   "out/",
   "target/",
   ".next/",


### PR DESCRIPTION
Hi, 

I noticed the ignore list in alwaysIgnore.ts has this glob: `"**/build/**"`.

This ends up ignoring any folder named `build` anywhere in a project — even if it’s just a normal source folder and not build output. That means those files won’t show up in Power Tower and can’t be added manually.

This PR changes it so only the root-level `build/` folder is ignored. That should still cover normal build output, but won’t hide other `build` folders that are part of the source.